### PR TITLE
Fix u32 conversion on 32bit arch

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,6 +1,6 @@
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
-use cast::u32;
+use std::convert::TryFrom;
 
 use crate::rsa;
 use crate::Digestable;
@@ -65,7 +65,7 @@ fn single_signature_valid(
 ) -> Result<(), Vec<SignatureError>> {
     digest.process(&sig.authenticated_data);
 
-    let len = match u32(sig.authenticated_data.len()) {
+    let len = match u32::try_from(sig.authenticated_data.len()) {
         Ok(len) => len,
         Err(_) => return Err(vec![SignatureError::BadData]),
     };


### PR DESCRIPTION
Hey there,

Still appreciate the work you put into gpgrv... I finally got around to including it in one of my projects (life, how it gets away from you...). I found when compiling for 32bit arches like arm, this error pops up...
```
error[E0308]: mismatched types
  --> src/verify.rs:69:9
   |
68 |     let len = match u32(sig.authenticated_data.len()) {
   |                     --------------------------------- this expression has type `u32`
69 |         Ok(len) => len,
   |         ^^^^^^^ expected `u32`, found enum `std::result::Result`
   |
   = note: expected type `u32`
              found enum `std::result::Result<_, _>`
```
Like here... https://travis-ci.org/github/lutostag/pincers/jobs/716405926#L400 This fixes that issue here.

The fix works on both 64bit + 32bit arches now :)

This fixes an issue on 32bit systems (like arm) where usize is already
u32 and so conversion will not lead to a Option type. This instead uses
the TryFrom trait as explained here: https://stackoverflow.com/a/55769098

Let me know if you have any comments/concerns. Appreciate the stewardship! Thanks!